### PR TITLE
Skip systemd redirect.

### DIFF
--- a/init.d/tracd
+++ b/init.d/tracd
@@ -12,6 +12,9 @@
 
 # Author: Arthur Furlan <afurlan@afurlan.org>
 
+# Skip systemd redirect.
+_SYSTEMCTL_SKIP_REDIRECT=OHYES
+
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DESC="tracd standalone server"
 NAME=tracd


### PR DESCRIPTION
Hello!

Debian has introduced systemd/systemctl instead of system scripts and the scripts will not work because, by default, debian redirects every init script to systemctl. The addition will make Debian not redirect to systemd and run the script.

Please apply if useful.

Regards,
Eva